### PR TITLE
Fix "slice bounds out of range"

### DIFF
--- a/sypex.go
+++ b/sypex.go
@@ -175,7 +175,12 @@ func (f *finder) unpack(seek, uType uint32) (map[string]interface{}, error) {
 		maxLen = f.MaxCity
 	}
 
-	raw := bs[seek : seek+maxLen]
+	limit := int(seek) + int(maxLen)
+	if limit > cap(bs) {
+		limit = cap(bs)
+	}
+
+	raw := bs[seek:limit]
 
 	var cursor int
 	for _, el := range strings.Split(f.Pack[uType], "/") {


### PR DESCRIPTION
I have `go version go1.17.2 darwin/amd64` installed.

I run this code:

```
package main

import (
	"log"

	"github.com/night-codes/go-sypexgeo"
)

func main() {
	sypex := sypexgeo.New("./SxGeoMax.dat")
	city, err := sypex.GetCityFull("14.8.48.96")
	if err != nil {
		log.Println("error: ", err)
		return
	}
	log.Print(city)
}

```

and it panics on this [line](https://github.com/night-codes/go-sypexgeo/blob/master/sypex.go#L178):
```
panic: runtime error: slice bounds out of range [:3428416] with capacity 3428328

goroutine 1 [running]:
github.com/night-codes/go-sypexgeo.(*finder).unpack(0xc000072e90, 0x344fb7, 0x2)
        /Users/alexandr/Development/sypex-panic-issue/vendor/github.com/night-codes/go-sypexgeo/sypex.go:183 +0xa49
github.com/night-codes/go-sypexgeo.(*finder).parseCity(0xc000072e90, 0x344fb7, 0x1)
        /Users/alexandr/Development/sypex-panic-issue/vendor/github.com/night-codes/go-sypexgeo/sypex.go:308 +0x34b
github.com/night-codes/go-sypexgeo.(*SxGEO).GetCityFull(0xc000072e90, {0x10ac91a, 0x600000003})
        /Users/alexandr/Development/sypex-panic-issue/vendor/github.com/night-codes/go-sypexgeo/sypex.go:365 +0x5e
main.main()
        /Users/alexandr/Development/sypex-panic-issue/main.go:11 +0x71
exit status 2
```

But on lower version `go1.15 run` it works as expected:
```
 .
2022/02/04 10:56:33 map[city:map[id:1859740 lat:35.90861 lon:139.48528 name_en:Kawagoe name_ru:Кавагоэ okato: post: tel:( vk:720896] country:map[capital_en:Tokyo capital_id:377835 capital_ru:�B�#;Токио continent:AS cur_code:JPY id:111 iso:JP lat:35.69 lon:139.75 name_en:Japan name_ru:Япония neighbours:� phone:81 timezone:Asia/Tokyo vk:5082368] region:map[auto:v��N��;��p�Ла-Пас id:1853226 iso:JP-11 lat:35.86 lon:139.65 name_en:Saitama-ken name_ru:Сайтама okato: timezone:Asia/Tokyo vk:7365956]]
```


While some debugging I've discovered that [ioutil.ReadFile](https://github.com/night-codes/go-sypexgeo/blob/master/sypex.go#L403) returns slices with different capacities

- go 1.17 - len = `39568043`, cap = `39568044` (it's less on `511 bytes`)
- go 1.15 - len = `39568043`, cap = `39568555`